### PR TITLE
Remove zypak-wrapper and electron runtime

### DIFF
--- a/codium.sh
+++ b/codium.sh
@@ -21,4 +21,4 @@ for i in "${SDK[@]}"; do
 done
 
 exec env PATH="${PATH}:${XDG_DATA_HOME}/node_modules/bin" \
-  zypak-wrapper /app/share/codium/bin/codium --extensions-dir=${XDG_DATA_HOME}/codium/extensions "$@" ${WARNING_FILE}
+  /app/share/codium/bin/codium --extensions-dir=${XDG_DATA_HOME}/codium/extensions "$@" ${WARNING_FILE}

--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -1,6 +1,4 @@
 app-id: com.vscodium.codium
-base: org.electronjs.Electron2.BaseApp
-base-version: '19.08'
 runtime: org.freedesktop.Sdk
 runtime-version: '19.08'
 sdk: org.freedesktop.Sdk


### PR DESCRIPTION
Neither this nor `--no-sandbox` is required as electron gets started  with `ELECTRON_RUN_AS_NODE=1`