### PR TITLE
Allow access to the user's keyring

### DIFF
--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -20,6 +20,7 @@ finish-args:
   - --env=NPM_CONFIG_GLOBALCONFIG=/app/etc/npmrc
   - --env=LD_LIBRARY_PATH=/app/lib
   - --filesystem=xdg-run/gnupg:ro
+  - --filesystem=xdg-run/keyring
   - --filesystem=xdg-config/kdeglobals:ro
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=com.canonical.AppMenu.Registrar.*


### PR DESCRIPTION
This commit makes it possible to automatically unlock a user's GPG key.
Previously, signing commits in VSCodium could fail unexpectedly.
This issue effected users storing the GPG key's passphrase in a keyring.
Even if the keyring was unlocked, like upon login, signing failed.
However, if the GPG key was unlocked elsewhere, then signing would work.
For instance, signing a commit on the command-line would load the key.
This enabled access for VSCodium, making the issue hard to reproduce.
This commit permits access to the user's keyring, solving the problem.
GPG key passphrases available in a keyring are now accessible.
When a user goes to sign a commit, everything will just work this way.
This assumes the keyring is unlocked and the passphrase stored therein.

For more details, refer to issue flathub/com.sublimemerge.App#18.
The Gitg Flatpak uses this permission as seen [here](https://github.com/flathub/org.gnome.gitg/blob/03a4f570e190edab7b675f64039adfe21a1af600/org.gnome.gitg.json#L21).