### PR TITLE
Enable Wayland socket by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ $ codium /path/to/
 $ FLATPAK_ENABLE_SDK_EXT=dotnet,golang codium /path/to/
 ```
 
+### Enable experimental native Wayland mode
+You can temporarily run VSCodium in experimental native Wayland mode with:  
+
+```
+flatpak run com.vscodium.codium --enable-features=UseOzonePlatform --ozone-platform=wayland
+```  
+
+Native Wayland can improve: HiDPI support, rendering performance, kinetic scrolling, touch support and also avoids needing xwayland. [See VSCode issue](https://github.com/microsoft/vscode/issues/109176). These flags are from Chromium and Electron, which currently consider native Wayland support experimental and opt-in. [See Electron issue](https://github.com/electron/electron/issues/10915).
+
+Note window decorations will currently be missing on GNOME/Mutter. [See this potential fix](https://github.com/electron/electron/pull/29618).
 
 ## Deprecation of arm(32bits) builds
 

--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -8,6 +8,7 @@ finish-args:
   - --require-version=0.10.3
   - --share=ipc
   - --socket=x11
+  - --socket=wayland
   - --socket=pulseaudio
   - --socket=ssh-auth
   - --share=network


### PR DESCRIPTION
You can run vscodium in native Wayland, but it only works if the socket is enabled.
When the socket is allowed run: `flatpak run com.vscodium.codium --enable-features=UseOzonePlatform --ozone-platform=wayland`
Note window decorations currently won't be present in GNOME when running in native Wayland.