### PR TITLE
Confine settings to flatpak environment

### DIFF
--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -14,6 +14,7 @@ finish-args:
   - --share=network
   - --device=all
   - --filesystem=host
+  - --persist=.vscode-oss
   - --allow=devel
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets


### PR DESCRIPTION
This uses the "--persist=path" option to prevent vscodium from unnecessarily writing its settings files outside the sandbox. 

See here for details: https://docs.flatpak.org/en/latest/sandbox-permissions.html