### PR TITLE
clarify sandboxing policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,13 @@ Please open issues under: https://github.com/flathub/com.vscodium.codium/issues
 
 ## FAQ
 
-Note that vscodium is granted *full host file system access*.
-You can use `flatpak override` to locally adjust this if you prefer to sandbox vscodium file system access.
+Note that vscodium is granted *full access to your home directory*.
+You can use `flatpak override` to locally adjust this if you prefer to sandbox vscodium file system access:
+```
+flatpak override --user com.vscodium.codium --nofilesystem=home
+# now manually grant accesss to the folder(s) you want to work in
+flatpak override --user com.vscodium.codium --filesystem=~/src
+```
 
 This version is running inside a _container_ and is therefore __not able__
 to access SDKs on your host system!
@@ -20,7 +25,10 @@ to access SDKs on your host system!
 ```
 
 Note that this runs the COMMAND without any further host-side confirmation.
-If you want to prevent such full host access from inside the sandbox, you can use `flatpak override` to remove access to the `org.freedesktop.Flatpak` bus.
+If you want to prevent such full host access from inside the sandbox, you can use `flatpak override` as follows:
+```
+flatpak override --user com.vscodium.codium --no-talk-name=org.freedesktop.Flatpak
+```
 
 ### Host Shell
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Please open issues under: https://github.com/flathub/com.vscodium.codium/issues
 
 ## FAQ
 
+Note that vscodium is granted *full host file system access*.
+You can use `flatpak override` to locally adjust this if you prefer to sandbox vscodium file system access.
+
 This version is running inside a _container_ and is therefore __not able__
 to access SDKs on your host system!
 
@@ -15,6 +18,9 @@ to access SDKs on your host system!
 ```bash
   $ flatpak-spawn --host <COMMAND>
 ```
+
+Note that this runs the COMMAND without any further host-side confirmation.
+If you want to prevent such full host access from inside the sandbox, you can use `flatpak override` to remove access to the `org.freedesktop.Flatpak` bus.
 
 ### Host Shell
 


### PR DESCRIPTION
Thanks a lot for packaging vscodium! This is very helpful.

However the default sandboxing policy is rather lax, so as a security-sensitive user I would have appreciated for that to be pointed out in the readme. I also didn't know about `flatpak override` since I am still new to flatpak. This way the default configuration can be made to work for a wide range of systems but it is still easy for users to figure out how to get a more sandboxed setup for themselves.