### PR TITLE
:bug: Revert to xwayland/x11 as default due to regression with ibus

### DIFF
--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -8,7 +8,7 @@ command: codium
 finish-args:
   - --share=ipc
   - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   - --socket=pulseaudio
   - --socket=ssh-auth
   - --share=network
@@ -134,10 +134,7 @@ modules:
         -Deditor_args=[
         '/app/share/codium/resources/app/out/cli.js',
         '--ms-enable-electron-run-as-node',
-        '--extensions-dir', '$XDG_DATA_HOME/codium/extensions',
-        '--disable-crash-reporter',
-        '--ozone-platform-hint=auto',
-        '--enable-features=WaylandWindowDecorations'
+        '--extensions-dir', '$XDG_DATA_HOME/codium/extensions'
         ]
       - -Dprogram_name=codium
       - -Deditor_title=VSCodium


### PR DESCRIPTION
ibus can't connect when codium is started on wayland mode,
The problem is reproducible on [upstream](https://github.com/microsoft/vscode/issues/167757)