### PR TITLE
Use fallback-x11 instead of x11

### DIFF
--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -8,7 +8,7 @@ command: codium
 finish-args:
   - --share=ipc
   - --socket=wayland
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=ssh-auth
   - --share=network


### PR DESCRIPTION
This allows Flatpak to deny access to the X-server if Wayland is available.

This should also fix the Gnome software manager reporting vscodium as insecure. Of course, there are more direct attack vectors due to permissions and filesystem access.