### PR TITLE
:heavy_minus_sign: Remove wrapper submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "shared-modules"]
 	path = shared-modules
 	url = https://github.com/flathub/shared-modules.git
-[submodule "wrapper"]
-	path = wrapper
-	url = https://github.com/flathub/ide-flatpak-wrapper.git


### PR DESCRIPTION
Due to migration into the build system