### PR TITLE
Remove notifications dbus permission

### DIFF
--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -15,7 +15,6 @@ finish-args:
   - --filesystem=xdg-config/gtk-3.0:ro
   - --persist=.vscode-oss
   - --allow=devel
-  - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.freedesktop.Flatpak
   - --env=LD_LIBRARY_PATH=/app/lib


### PR DESCRIPTION
23.08 branch of Electron baseapp includes libnotify 0.8.3 which automatically uses the portal when run inside a sandbox for notifications

This just cleans up an unused permission, the actual relevant change happened when the runtime was bumped to 23.08

See https://gitlab.gnome.org/GNOME/libnotify/-/blob/69aff6e5fa2842e00b409c348bd73188548828b3/NEWS#L25