### PR TITLE
Updated URL to VSCodium documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,5 +104,5 @@ supported until 2021, you can read more about it
 
 ## Related Documentation
 
-- https://github.com/VSCodium/vscodium/blob/master/DOCS.md
+- https://github.com/VSCodium/vscodium/blob/master/docs/index.md
 - https://code.visualstudio.com/docs#vscode


### PR DESCRIPTION
Hi,

The current link yields a 404.

So updated URL to point to VSCodium's `docs/index.md`.