### PR TITLE
added host-spawn and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,13 @@ to access SDKs on your host system!
 
 ### To execute commands on the host system, run inside the sandbox:
 
-```bash
-  $ flatpak-spawn --host <COMMAND>
-```
+  `$ flatpak-spawn --host <COMMAND>`
+
+  or
+
+  `$ host-spawn <COMMAND>`
+
+  - Most users seem to report a better experience with `host-spawn`
 
 Note that this runs the COMMAND without any further host-side confirmation.
 If you want to prevent such full host access from inside the sandbox, you can use `flatpak override` as follows:
@@ -38,18 +42,36 @@ Since are serveral ways to achieve this the better is to use [vsix-manager](http
 To make the Integrated Terminal automatically use the host system's shell,
 you can add this to the settings of vscodium:
 
+
+`flatpak-spawn`
+
 ```json
   {
     "terminal.integrated.defaultProfile.linux": "bash",
     "terminal.integrated.profiles.linux": {
         "bash": {
           "path": "/usr/bin/flatpak-spawn",
-          "args": ["--host", "--env=TERM=xterm-256color", "bash"]
+          "args": ["--host", "--env=TERM=xterm-256color", "bash"],
+          "icon": "terminal-bash",
+          "overrideName": true
         }
     },
   }
 ```
+`host-spawn`
 
+```json
+    "terminal.integrated.defaultProfile.linux": "bash",
+    "bash": {
+      "path": "/app/bin/host-spawn",
+      "args": ["bash"],
+      "icon": "terminal-bash",
+      "overrideName": true
+    },
+```
+
+- You can change **bash** to any terminal you are using: zsh, fish, sh.
+- `overrideName` allows for the 'name' (or whatever you set it to) of the shell you're using to appear (e.g. normally zsh, fish, sh).
 ### SDKs
 
 This flatpak provides a standard development environment (gcc, python, etc).
@@ -80,7 +102,7 @@ If you want to run `codium /path/to/file` from the host terminal just add this
 to your shell's rc file
 
 ```bash
-alias codium="flatpak run com.vscodium.codium "
+$ alias codium="flatpak run com.vscodium.codium "
 ```
 
 then reload sources, now you could try:

--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -136,6 +136,21 @@ modules:
         url: https://github.com/refi64/zypak.git
         branch: main
         commit: ded79a2f8a509adc21834b95a9892073d4a91fdc
+  - name: host-spawn
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 host-spawn /app/bin/host-spawn
+    sources:
+      - type: file
+        url: https://github.com/1player/host-spawn/releases/download/1.5.0/host-spawn-x86_64
+        sha256: dbf67e7e111c4fe1edb0c642cbb4193064ca5b384aeb1054fc2befba6ed88b83
+        dest-filename: host-spawn
+        only-arches: [x86_64]
+      - type: file
+        url: https://github.com/1player/host-spawn/releases/download/1.5.0/host-spawn-aarch64
+        sha256: c42c12be6cdd83e374b847bec836659fb45231215797777c9ee1c9c0ae9e3783
+        dest-filename: host-spawn
+        only-arches: [aarch64] 
   - name: wrapper-flatpak-wrapper
     buildsystem: meson
     config-opts:


### PR DESCRIPTION
I tried to keep this PR as close to the one merged in the vscode repo: https://github.com/flathub/com.visualstudio.code/commit/db41a6cac095f653dee755ccac632391981647df This will add host-spawn which will allow for better interactivity to the host terminal from flatpak.

Fixes #255