### PR TITLE
corrected configuration for host-spawn and reworded readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Since are serveral ways to achieve this the better is to use [vsix-manager](http
 ### Host Shell
 
 To make the Integrated Terminal automatically use the host system's shell,
-you can add this to the settings of vscodium:
+you can add one of the following configurations for flatpak-spawn or host-spawn to the settings of vscodium:
 
 
 `flatpak-spawn`
@@ -49,25 +49,30 @@ you can add this to the settings of vscodium:
   {
     "terminal.integrated.defaultProfile.linux": "bash",
     "terminal.integrated.profiles.linux": {
-        "bash": {
-          "path": "/usr/bin/flatpak-spawn",
-          "args": ["--host", "--env=TERM=xterm-256color", "bash"],
-          "icon": "terminal-bash",
-          "overrideName": true
-        }
+      "bash": {
+        "path": "/usr/bin/flatpak-spawn",
+        "args": ["--host", "--env=TERM=xterm-256color", "bash"],
+        "icon": "terminal-bash",
+        "overrideName": true
+      }
     },
   }
 ```
+
 `host-spawn`
 
 ```json
+  {
     "terminal.integrated.defaultProfile.linux": "bash",
-    "bash": {
-      "path": "/app/bin/host-spawn",
-      "args": ["bash"],
-      "icon": "terminal-bash",
-      "overrideName": true
+    "terminal.integrated.profiles.linux": {
+      "bash": {
+        "path": "/app/bin/host-spawn",
+        "args": ["bash"],
+        "icon": "terminal-bash",
+        "overrideName": true
+      }
     },
+  }
 ```
 
 - You can change **bash** to any terminal you are using: zsh, fish, sh.


### PR DESCRIPTION
Found that the README has the incorrect configuration for host-spawn. Also, cleaned up some wording stating to pick one of the following configurations specified.

I've tested both the flatpak-spawn and host-spawn. Both appear to be working as expected. I will push this config to vscode flatpak repo as well.