### PR TITLE
Allow access to .gitconfig

### DIFF
--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -20,7 +20,7 @@ finish-args:
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
   - --filesystem=xdg-run/gnupg:ro
   - --filesystem=xdg-config/kdeglobals:ro
-  - --filesystem=~/.gitconfig:create
+  - --filesystem=~/.gitconfig
   - --talk-name=com.canonical.AppMenu.Registrar
   - --system-talk-name=org.freedesktop.login1
 separate-locales: false

--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -20,6 +20,7 @@ finish-args:
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
   - --filesystem=xdg-run/gnupg:ro
   - --filesystem=xdg-config/kdeglobals:ro
+  - --filesystem=~/.gitconfig:create
   - --talk-name=com.canonical.AppMenu.Registrar
   - --system-talk-name=org.freedesktop.login1
 separate-locales: false


### PR DESCRIPTION
By default, VSCodium flatpak is allowed full access to an user's home directory.
The FAQ guides users on how to disable the home directory access and enable access to specific directory.

But doing so breaks committing/pushing to git repos as VSCodium loses access to ~/.gitconfig and errors out.
This is why I have created this PR, It introduces a one-line change that explicitly grants access to ~/.gitconfig , so in the case the user decides to disable home directory access and grant access to a specific directory, git still continues to function.

Note that --persist can also be used instead of --filesystem to isolate the ~/.gitconfig file from user's own home.