### PR TITLE
Workaround the sync issue

### DIFF
--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -133,7 +133,8 @@ modules:
         -Deditor_args=[
         '/app/share/codium/resources/app/out/cli.js',
         '--ms-enable-electron-run-as-node',
-        '--extensions-dir', '$XDG_DATA_HOME/codium/extensions'
+        '--extensions-dir', '$XDG_DATA_HOME/codium/extensions',
+        '--password-store="basic"'
         ]
       - -Dprogram_name=codium
       - -Deditor_title=VSCodium


### PR DESCRIPTION
This PR adds --password-store="basic" launch argument to the -Deditor_args= section of the flatpak manifest file to workaround sync being broken (Github credentials getting reset everytime you close VSC)