### PR TITLE
Enable wayland

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build-dir/
 builddir/
 repo/
+vscrepo

--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -133,7 +133,7 @@ modules:
         -Deditor_args=[
         '/app/share/codium/resources/app/out/cli.js',
         '--ms-enable-electron-run-as-node',
-        '--extensions-dir', '$XDG_DATA_HOME/codium/extensions'
+        '--extensions-dir', '$XDG_DATA_HOME/codium/extensions',
 
         '--enable-features=UseOzonePlatform,WaylandWindowDecorations',
         '--ozone-platform-hint=auto'

--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -134,6 +134,9 @@ modules:
         '/app/share/codium/resources/app/out/cli.js',
         '--ms-enable-electron-run-as-node',
         '--extensions-dir', '$XDG_DATA_HOME/codium/extensions'
+
+        '--enable-features=UseOzonePlatform,WaylandWindowDecorations',
+        '--ozone-platform-hint=auto'
         ]
       - -Dprogram_name=codium
       - -Deditor_title=VSCodium

--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -5,8 +5,8 @@ runtime-version: '23.08'
 command: codium
 finish-args:
   - --share=ipc
-  - --socket=x11
   - --socket=wayland
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=ssh-auth
   - --share=network


### PR DESCRIPTION
This PR adds necessary launch args to the -Deditor_args= section of the flatpak manifest to enable native wayland by default.
Note that for the launch arguments to work, --socket=X11 needs to be disabled and --socket=wayland and --socket=fallback-x11 needs to be enabled

During testing, I noticed that,
- When my DE/WM is running under native wayland.
- Even if I manually disabled the wayland socket and enabled the x11 socket by adding --nosocket=wayland --socket=x11 to run VSCodium.
- so my args are 'flatpak run --user--nosocket=wayland --socket=x11 com.vscodium.codium'
- It will refuse to run using X11 via Xwayland.
- But, when running my DE (GNOME) under the X11 session, VSC does seem to launch under X11 just fine.

It seems like some quirk with --ozone-platform-hint=auto. So far,
- Wayland users can run VSC under native Wayland
- X11 users can run VSC under X11
- Wayland users CAN'T run VSC using X11 via Xwayland

The maintainers might want to consider this while reviewing this PR.