### PR TITLE
Fix display server args

### DIFF
--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -132,7 +132,6 @@ modules:
       - >-
         -Deditor_args=[
         '/app/share/codium/resources/app/out/cli.js',
-        '--ms-enable-electron-run-as-node',
         '--extensions-dir', '$XDG_DATA_HOME/codium/extensions',
         '--ozone-platform-hint=auto',
         '--enable-features=WaylandWindowDecorations',

--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -132,9 +132,7 @@ modules:
       - >-
         -Deditor_args=[
         '/app/share/codium/resources/app/out/cli.js',
-        '--extensions-dir', '$XDG_DATA_HOME/codium/extensions',
-        '--ozone-platform-hint=auto',
-        '--enable-features=WaylandWindowDecorations',
+        '--extensions-dir', '$XDG_DATA_HOME/codium/extensions'
         ]
       - -Dprogram_name=codium
       - -Deditor_title=VSCodium

--- a/com.vscodium.codium.yaml
+++ b/com.vscodium.codium.yaml
@@ -151,9 +151,8 @@ modules:
       - -Dflagfile_prefix=flatpak-vscodium
     sources:
       - type: git
-        url: https://github.com/flathub/ide-flatpak-wrapper.git
-        branch: zypak
-        commit: 188d2145b3460173558147ebefa288eb2a7d56f1
+        url: https://github.com/noonsleeper/ide-flatpak-wrapper.git
+        commit: 3c0635635e4d056a6d18d79c10f66db67de98a93
       - type: file
         path: README.md
       - type: file


### PR DESCRIPTION
If `socket=wayland` is active the parameters to handle wayland decorations is set also `ozone-platform-hint=auto` is set.

If you override with `nosocket=wayland` force `ozone-platform=x11`
