### PR TITLE
change desktopName to com.vscodium.codium so wayland DE's correctly match the desktop file

### DIFF
--- a/patches/package.json.patch
+++ b/patches/package.json.patch
@@ -5,5 +5,5 @@
 -  "desktopName": "codium.desktop"
 -}
 \ No newline at end of file
-+  "desktopName": "com.vscodium.codium-url-handler.desktop"
++  "desktopName": "com.vscodium.codium.desktop"
 +}


### PR DESCRIPTION
hello!

on COSMIC, the application tray matches the `com.vscodium.codium-url-handler.desktop` file when i launch the flatpak. this shows the correct icon (this was the original fix for #149 ) however does not show the correct name or actions:

before:
![Screenshot_2025-06-05_23-25-06](https://github.com/user-attachments/assets/e057afcf-fa0c-4558-bc74-05dc078eb71c)

after:
![Screenshot_2025-06-05_23-24-36](https://github.com/user-attachments/assets/d0813336-c3e7-4e81-a6e3-1bb8418c6229)

(the after also correctly shows the name as `VSCodium`, i just suck at taking screenshots lol)