### PR TITLE
doc: link to host-spawn docs to find out more about it

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ to access SDKs on your host system!
 
   `$ host-spawn <COMMAND>`
 
-  - Most users seem to report a better experience with `host-spawn`
+  - Most users seem to report a better experience with [`host-spawn`](https://github.com/1player/host-spawn).
 
 Note that this runs the COMMAND without any further host-side confirmation.
 If you want to prevent such full host access from inside the sandbox, you can use `flatpak override` as follows:


### PR DESCRIPTION
Because the first thing I did when reading this is to [search for what is now the difference](https://duckduckgo.com/?t=ffab&q=host-spawn+vs+flatpak-spawn&ia=web) and why users may report better results, just to find [that information at the end of the GitHub page](https://github.com/1player/host-spawn?tab=readme-ov-file#improvements-over-flatpak-spawn---host).